### PR TITLE
Introduce Dagger Hilt to the app. (fixes #19) 🗡

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'com.android.application'
+    id 'dagger.hilt.android.plugin'
     id 'kotlin-android'
     id 'kotlin-kapt' // TODO Migrate to KSP when stable
 }
@@ -56,12 +57,16 @@ dependencies {
     implementation libs.fragment
     implementation libs.preference
 
-    // Navigation
-    implementation libs.navigation.fragment
-    implementation libs.navigation.ui
+    // Hilt
+    implementation libs.hilt.core
+    kapt libs.hilt.compiler
 
     // Material Components
     implementation libs.material
+
+    // Navigation
+    implementation libs.navigation.fragment
+    implementation libs.navigation.ui
 
     // Room
     implementation libs.room.core
@@ -75,13 +80,21 @@ dependencies {
     implementation libs.logcat
     implementation libs.eaze.graph
 
-    // Testing
+    // Unit Tests
     testImplementation libs.junit
-    androidTestImplementation libs.core.testing
+
+    // Instrumentation tests
     androidTestImplementation libs.androidx.junit
     androidTestImplementation libs.androidx.test.rules
     androidTestImplementation libs.androidx.test.runner
+    androidTestImplementation libs.hilt.testing
+    androidTestImplementation libs.core.testing
     androidTestImplementation libs.work.testing
+    kaptAndroidTest libs.hilt.compiler
+}
+
+kapt {
+    correctErrorTypes true
 }
 
 def props = new Properties()

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,12 +5,12 @@ plugins {
 }
 
 android {
-    compileSdkVersion = 30
+    compileSdk = 30
 
     defaultConfig {
         applicationId "dev.sjaramillo.pedometer"
-        targetSdkVersion 30 // Check https://github.com/sjaramillo10/Pedometer/pull/14 before increasing version
-        minSdkVersion 21
+        targetSdk 30 // Check https://github.com/sjaramillo10/Pedometer/pull/14 before increasing version
+        minSdk 21
         versionCode 1
         versionName "0.1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,8 @@
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-kapt' // TODO Migrate to KSP when stable
+plugins {
+    id 'com.android.application'
+    id 'kotlin-android'
+    id 'kotlin-kapt' // TODO Migrate to KSP when stable
+}
 
 android {
     compileSdkVersion = 30
@@ -48,42 +50,38 @@ dependencies {
     // Enable Java 8+ API desugaring
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.1.5")
 
-    def nav_version = "2.3.5"
-    def roomVersion = "2.3.0"
-    def work_version = "2.6.0" // Check https://github.com/sjaramillo10/Pedometer/pull/14 before increasing version
-
     // AndroidX
-    implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation 'androidx.activity:activity-ktx:1.3.1'
-    implementation 'androidx.fragment:fragment-ktx:1.3.6'
-    implementation 'androidx.preference:preference-ktx:1.1.1'
+    implementation libs.appcompat
+    implementation libs.activity
+    implementation libs.fragment
+    implementation libs.preference
 
     // Navigation
-    implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
-    implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
+    implementation libs.navigation.fragment
+    implementation libs.navigation.ui
 
     // Material Components
-    implementation 'com.google.android.material:material:1.4.0'
+    implementation libs.material
 
     // Room
-    implementation "androidx.room:room-runtime:$roomVersion"
-    implementation "androidx.room:room-ktx:$roomVersion"
-    kapt "androidx.room:room-compiler:$roomVersion"
+    implementation libs.room.core
+    implementation libs.room.runtime
+    kapt libs.room.compiler
 
     // WorkManager
-    implementation "androidx.work:work-runtime-ktx:$work_version"
+    implementation libs.work.runtime
 
     // Other
-    implementation 'com.squareup.logcat:logcat:0.1'
-    implementation 'com.github.j4velin.EazeGraph:EazeGraph:1.0.3'
+    implementation libs.logcat
+    implementation libs.eaze.graph
 
     // Testing
-    testImplementation "junit:junit:4.13.2"
-    androidTestImplementation "androidx.arch.core:core-testing:2.1.0"
-    androidTestImplementation "androidx.test.ext:junit:1.1.3"
-    androidTestImplementation "androidx.test:rules:1.4.0"
-    androidTestImplementation "androidx.test:runner:1.4.0"
-    androidTestImplementation "androidx.work:work-testing:$work_version"
+    testImplementation libs.junit
+    androidTestImplementation libs.core.testing
+    androidTestImplementation libs.androidx.junit
+    androidTestImplementation libs.androidx.test.rules
+    androidTestImplementation libs.androidx.test.runner
+    androidTestImplementation libs.work.testing
 }
 
 def props = new Properties()

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -58,6 +58,8 @@ dependencies {
     implementation libs.preference
 
     // Hilt
+    implementation libs.androidx.hilt.work
+    kapt libs.androidx.hilt.compiler
     implementation libs.hilt.core
     kapt libs.hilt.compiler
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -49,6 +49,14 @@
                 <action android:name="android.intent.action.MY_PACKAGE_REPLACED"/>
             </intent-filter>
         </receiver>
+
+        <!-- Remove androidx.startup to allow custom WorkManager initialization -->
+        <!-- More info: https://developer.android.com/training/dependency-injection/hilt-jetpack#workmanager -->
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            tools:node="remove">
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/kotlin/dev/sjaramillo/pedometer/PedometerApplication.kt
+++ b/app/src/main/kotlin/dev/sjaramillo/pedometer/PedometerApplication.kt
@@ -1,15 +1,27 @@
 package dev.sjaramillo.pedometer
 
 import android.app.Application
+import androidx.hilt.work.HiltWorkerFactory
+import androidx.work.Configuration
 import dagger.hilt.android.HiltAndroidApp
 import logcat.AndroidLogcatLogger
 import logcat.LogPriority.VERBOSE
+import javax.inject.Inject
 
 @HiltAndroidApp
-class PedometerApplication : Application() {
+class PedometerApplication : Application(), Configuration.Provider {
+
+    @Inject
+    lateinit var workerFactory: HiltWorkerFactory
+
     override fun onCreate() {
         super.onCreate()
         // Log all priorities in debug builds, no-op in release builds.
         AndroidLogcatLogger.installOnDebuggableApp(this, minPriority = VERBOSE)
     }
+
+    override fun getWorkManagerConfiguration() =
+        Configuration.Builder()
+            .setWorkerFactory(workerFactory)
+            .build()
 }

--- a/app/src/main/kotlin/dev/sjaramillo/pedometer/PedometerApplication.kt
+++ b/app/src/main/kotlin/dev/sjaramillo/pedometer/PedometerApplication.kt
@@ -1,9 +1,11 @@
 package dev.sjaramillo.pedometer
 
 import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
 import logcat.AndroidLogcatLogger
 import logcat.LogPriority.VERBOSE
 
+@HiltAndroidApp
 class PedometerApplication : Application() {
     override fun onCreate() {
         super.onCreate()

--- a/app/src/main/kotlin/dev/sjaramillo/pedometer/data/StepsRepository.kt
+++ b/app/src/main/kotlin/dev/sjaramillo/pedometer/data/StepsRepository.kt
@@ -1,10 +1,10 @@
 package dev.sjaramillo.pedometer.data
 
 import dev.sjaramillo.pedometer.util.DateUtil
+import javax.inject.Inject
 import kotlin.math.max
 
-// TODO Provide through DI
-class StepsRepository(db: PedometerDatabase) {
+class StepsRepository @Inject constructor(db: PedometerDatabase) {
 
     private val dailyStepsDao = db.dailyStepsDao()
 

--- a/app/src/main/kotlin/dev/sjaramillo/pedometer/di/module/PersistenceModule.kt
+++ b/app/src/main/kotlin/dev/sjaramillo/pedometer/di/module/PersistenceModule.kt
@@ -1,0 +1,21 @@
+package dev.sjaramillo.pedometer.di.module
+
+import android.content.Context
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import dev.sjaramillo.pedometer.data.PedometerDatabase
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+class PersistenceModule {
+
+    @Provides
+    @Singleton
+    fun provideDatabase(@ApplicationContext context: Context): PedometerDatabase {
+        return PedometerDatabase.getInstance(context)
+    }
+}

--- a/app/src/main/kotlin/dev/sjaramillo/pedometer/receiver/BootReceiver.kt
+++ b/app/src/main/kotlin/dev/sjaramillo/pedometer/receiver/BootReceiver.kt
@@ -18,20 +18,25 @@ package dev.sjaramillo.pedometer.receiver
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import dev.sjaramillo.pedometer.data.PedometerDatabase
+import dagger.hilt.android.AndroidEntryPoint
 import dev.sjaramillo.pedometer.data.StepsRepository
 import dev.sjaramillo.pedometer.worker.StepsCounterWorker
 import logcat.logcat
+import javax.inject.Inject
 
 // TODO Figure out if this Receiver is necessary. WorkManager is persisted.
+@AndroidEntryPoint
 class BootReceiver : BroadcastReceiver() {
+
+    @Inject
+    lateinit var stepsRepository: StepsRepository
+
     override fun onReceive(context: Context, intent: Intent) {
         if (intent.action != Intent.ACTION_BOOT_COMPLETED) return
 
         logcat { "Device booted" }
 
         // Make sure to reset the steps since boot in the db
-        val stepsRepository = StepsRepository(PedometerDatabase.getInstance(context))
         stepsRepository.updateStepsSinceBoot(0)
 
         StepsCounterWorker.enqueuePeriodicWork(context)

--- a/app/src/main/kotlin/dev/sjaramillo/pedometer/ui/HomeFragment.kt
+++ b/app/src/main/kotlin/dev/sjaramillo/pedometer/ui/HomeFragment.kt
@@ -28,7 +28,6 @@ import android.widget.TextView
 import androidx.fragment.app.Fragment
 import dagger.hilt.android.AndroidEntryPoint
 import dev.sjaramillo.pedometer.R
-import dev.sjaramillo.pedometer.data.PedometerDatabase
 import dev.sjaramillo.pedometer.data.StepsRepository
 import dev.sjaramillo.pedometer.util.DateUtil
 import dev.sjaramillo.pedometer.util.FormatUtil
@@ -259,7 +258,7 @@ class HomeFragment : Fragment(), SensorEventListener {
         }
         if (barChart.data.size > 0) {
             barChart.setOnClickListener {
-                StatisticsDialog.getDialog(requireContext()).show()
+                StatisticsDialog.getDialog(requireContext(), stepsRepository).show()
             }
             barChart.startAnimation()
         } else {

--- a/app/src/main/kotlin/dev/sjaramillo/pedometer/ui/HomeFragment.kt
+++ b/app/src/main/kotlin/dev/sjaramillo/pedometer/ui/HomeFragment.kt
@@ -26,6 +26,7 @@ import android.os.Bundle
 import android.view.*
 import android.widget.TextView
 import androidx.fragment.app.Fragment
+import dagger.hilt.android.AndroidEntryPoint
 import dev.sjaramillo.pedometer.R
 import dev.sjaramillo.pedometer.data.PedometerDatabase
 import dev.sjaramillo.pedometer.data.StepsRepository
@@ -38,11 +39,16 @@ import org.eazegraph.lib.charts.PieChart
 import org.eazegraph.lib.models.BarModel
 import org.eazegraph.lib.models.PieModel
 import java.time.format.DateTimeFormatter
+import javax.inject.Inject
 import kotlin.math.roundToLong
 
 // TODO cleanup this file
 // TODO Use ViewBinding or not? Maybe go straight to Compose!
+@AndroidEntryPoint
 class HomeFragment : Fragment(), SensorEventListener {
+
+    @Inject
+    lateinit var stepsRepository: StepsRepository
 
     private lateinit var stepsView: TextView
     private lateinit var totalView: TextView
@@ -55,15 +61,12 @@ class HomeFragment : Fragment(), SensorEventListener {
     private var totalDays = 0L
     private var showSteps = true
 
-    private lateinit var stepsRepository: StepsRepository
-
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
         setHasOptionsMenu(true)
-        stepsRepository = StepsRepository(PedometerDatabase.getInstance(requireContext()))
 
         val v = inflater.inflate(R.layout.fragment_home, container, false)
         stepsView = v.findViewById<View>(R.id.steps) as TextView

--- a/app/src/main/kotlin/dev/sjaramillo/pedometer/ui/MainActivity.kt
+++ b/app/src/main/kotlin/dev/sjaramillo/pedometer/ui/MainActivity.kt
@@ -34,9 +34,11 @@ import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.setupActionBarWithNavController
 import androidx.navigation.ui.setupWithNavController
 import com.google.android.material.bottomnavigation.BottomNavigationView
+import dagger.hilt.android.AndroidEntryPoint
 import dev.sjaramillo.pedometer.R
 import dev.sjaramillo.pedometer.worker.StepsCounterWorker
 
+@AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/kotlin/dev/sjaramillo/pedometer/ui/SettingsFragment.kt
+++ b/app/src/main/kotlin/dev/sjaramillo/pedometer/ui/SettingsFragment.kt
@@ -22,25 +22,33 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
-import android.view.*
+import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.WindowManager
 import android.widget.EditText
 import android.widget.NumberPicker
 import android.widget.RadioGroup
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
+import dagger.hilt.android.AndroidEntryPoint
 import dev.sjaramillo.pedometer.R
-import dev.sjaramillo.pedometer.data.PedometerDatabase
 import dev.sjaramillo.pedometer.data.StepsRepository
 import java.io.FileNotFoundException
 import java.io.FileOutputStream
 import java.io.FileReader
 import java.io.IOException
 import java.util.*
+import javax.inject.Inject
 import kotlin.math.max
 
 // TODO cleanup this file
 // TODO Use ViewBinding or not? Maybe go straight to Compose!
+@AndroidEntryPoint
 class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceClickListener {
+
+    @Inject
+    lateinit var stepsRepository: StepsRepository
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.settings, rootKey)
@@ -178,7 +186,6 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceClic
      */
     private fun writeDataToCsv(uri: Uri) {
         val contentResolver = requireContext().applicationContext.contentResolver
-        val stepsRepository = StepsRepository(PedometerDatabase.getInstance(requireContext()))
         val dailySteps = stepsRepository.getAll()
         try {
             contentResolver.openFileDescriptor(uri, "w")?.use {
@@ -216,7 +223,6 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceClic
      */
     private fun readDataFromCsv(uri: Uri) {
         val contentResolver = requireContext().applicationContext.contentResolver
-        val stepsRepository = StepsRepository(PedometerDatabase.getInstance(requireContext()))
         var ignored = 0
         var inserted = 0
         var overwritten = 0

--- a/app/src/main/kotlin/dev/sjaramillo/pedometer/ui/StatisticsDialog.kt
+++ b/app/src/main/kotlin/dev/sjaramillo/pedometer/ui/StatisticsDialog.kt
@@ -30,9 +30,7 @@ import java.time.format.DateTimeFormatter
 // TODO Extend from Dialog class
 // TODO Maybe wait to add a StatsFragment instead?
 object StatisticsDialog {
-    fun getDialog(context: Context): Dialog {
-        // TODO Inject Repository or ViewModel
-        val stepsRepository = StepsRepository(PedometerDatabase.getInstance(context))
+    fun getDialog(context: Context, stepsRepository: StepsRepository): Dialog {
         val record = stepsRepository.getRecord()
         val recordDate = DateUtil.dayToLocalDate(record.day)
         val today = DateUtil.getToday()

--- a/app/src/main/kotlin/dev/sjaramillo/pedometer/worker/StepsCounterWorker.kt
+++ b/app/src/main/kotlin/dev/sjaramillo/pedometer/worker/StepsCounterWorker.kt
@@ -16,7 +16,6 @@ import androidx.work.*
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import dev.sjaramillo.pedometer.R
-import dev.sjaramillo.pedometer.data.PedometerDatabase
 import dev.sjaramillo.pedometer.data.StepsRepository
 import logcat.logcat
 import java.util.concurrent.TimeUnit

--- a/app/src/main/kotlin/dev/sjaramillo/pedometer/worker/StepsCounterWorker.kt
+++ b/app/src/main/kotlin/dev/sjaramillo/pedometer/worker/StepsCounterWorker.kt
@@ -11,28 +11,33 @@ import android.hardware.SensorManager
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
+import androidx.hilt.work.HiltWorker
 import androidx.work.*
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
 import dev.sjaramillo.pedometer.R
 import dev.sjaramillo.pedometer.data.PedometerDatabase
 import dev.sjaramillo.pedometer.data.StepsRepository
 import logcat.logcat
 import java.util.concurrent.TimeUnit
+import javax.inject.Inject
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
-// TODO Inject repository
 /**
  * Attempts to obtain a reading from the device's step sensor to update the app's
  * step count.
  */
-class StepsCounterWorker(appContext: Context, workerParams: WorkerParameters) :
-    CoroutineWorker(appContext, workerParams) {
+@HiltWorker
+class StepsCounterWorker @AssistedInject constructor(
+    @Assisted appContext: Context,
+    @Assisted workerParams: WorkerParameters
+) : CoroutineWorker(appContext, workerParams) {
 
-    private lateinit var stepsRepository: StepsRepository
+    @Inject
+    lateinit var stepsRepository: StepsRepository
 
     override suspend fun doWork(): Result {
-
-        stepsRepository = StepsRepository(PedometerDatabase.getInstance(applicationContext))
 
         setForeground(getForegroundInfo())
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.2'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.30'
+        classpath libs.android.gradle.plugin
+        classpath libs.kotlin.gradle.plugin
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
     }
     dependencies {
         classpath libs.android.gradle.plugin
+        classpath libs.hilt.gradle.plugin
         classpath libs.kotlin.gradle.plugin
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ appcompat = "1.3.1"
 core-testing = "2.1.0"
 eaze-graph = "1.0.3"
 fragment = "1.3.6"
+hilt = "2.40"
 junit = "4.13.2"
 kotlin = "1.5.30"
 logcat = "0.1"
@@ -26,6 +27,10 @@ appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat"
 core-testing = { module = "androidx.arch.core:core-testing", version.ref = "core-testing" }
 eaze-graph = { module = "com.github.j4velin.EazeGraph:EazeGraph", version.ref = "eaze-graph"}
 fragment = { module = "androidx.fragment:fragment-ktx", version.ref = "fragment" }
+hilt-core = { module ="com.google.dagger:hilt-android", version.ref = "hilt" }
+hilt-testing = { module ="com.google.dagger:hilt-android-testing", version.ref = "hilt" }
+hilt-compiler = { module ="com.google.dagger:hilt-compiler", version.ref = "hilt" }
+hilt-gradle-plugin = { module = "com.google.dagger:hilt-android-gradle-plugin", version.ref = "hilt" }
 junit = { module = "junit:junit", version.ref = "junit" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 logcat = { module = "com.squareup.logcat:logcat", version.ref = "logcat" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 activity = "1.3.1"
 android-gradle-plugin = "7.0.2"
+androidx-hilt = "1.0.0"
 androidx-junit = "1.1.3"
 androidx-test = "1.4.0"
 appcompat = "1.3.1"
@@ -20,6 +21,8 @@ work = "2.6.0" # Check https://github.com/sjaramillo10/Pedometer/pull/14 before 
 [libraries]
 activity = { module = "androidx.activity:activity-ktx", version.ref = "activity" }
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "android-gradle-plugin" }
+androidx-hilt-work = { module = "androidx.hilt:hilt-work", version.ref = "androidx-hilt" }
+androidx-hilt-compiler = { module = "androidx.hilt:hilt-compiler", version.ref = "androidx-hilt" }
 androidx-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-junit" }
 androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidx-test" }
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidx-test" }
@@ -28,9 +31,9 @@ core-testing = { module = "androidx.arch.core:core-testing", version.ref = "core
 eaze-graph = { module = "com.github.j4velin.EazeGraph:EazeGraph", version.ref = "eaze-graph"}
 fragment = { module = "androidx.fragment:fragment-ktx", version.ref = "fragment" }
 hilt-core = { module ="com.google.dagger:hilt-android", version.ref = "hilt" }
-hilt-testing = { module ="com.google.dagger:hilt-android-testing", version.ref = "hilt" }
 hilt-compiler = { module ="com.google.dagger:hilt-compiler", version.ref = "hilt" }
 hilt-gradle-plugin = { module = "com.google.dagger:hilt-android-gradle-plugin", version.ref = "hilt" }
+hilt-testing = { module ="com.google.dagger:hilt-android-testing", version.ref = "hilt" }
 junit = { module = "junit:junit", version.ref = "junit" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 logcat = { module = "com.squareup.logcat:logcat", version.ref = "logcat" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,40 @@
+[versions]
+activity = "1.3.1"
+android-gradle-plugin = "7.0.2"
+androidx-junit = "1.1.3"
+androidx-test = "1.4.0"
+appcompat = "1.3.1"
+core-testing = "2.1.0"
+eaze-graph = "1.0.3"
+fragment = "1.3.6"
+junit = "4.13.2"
+kotlin = "1.5.30"
+logcat = "0.1"
+material = "1.4.0"
+navigation = "2.3.5"
+preference = "1.1.1"
+room = "2.3.0"
+work = "2.6.0" # Check https://github.com/sjaramillo10/Pedometer/pull/14 before increasing version
+
+[libraries]
+activity = { module = "androidx.activity:activity-ktx", version.ref = "activity" }
+android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "android-gradle-plugin" }
+androidx-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-junit" }
+androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidx-test" }
+androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidx-test" }
+appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
+core-testing = { module = "androidx.arch.core:core-testing", version.ref = "core-testing" }
+eaze-graph = { module = "com.github.j4velin.EazeGraph:EazeGraph", version.ref = "eaze-graph"}
+fragment = { module = "androidx.fragment:fragment-ktx", version.ref = "fragment" }
+junit = { module = "junit:junit", version.ref = "junit" }
+kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+logcat = { module = "com.squareup.logcat:logcat", version.ref = "logcat" }
+material = { module = "com.google.android.material:material", version.ref = "material" }
+navigation-fragment = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "navigation" }
+navigation-ui = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "navigation" }
+preference = { module = "androidx.preference:preference-ktx", version.ref = "preference" }
+room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
+room-core = { module = "androidx.room:room-ktx", version.ref = "room" }
+room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
+work-runtime = { module = "androidx.work:work-runtime-ktx", version.ref = "work" }
+work-testing = { module = "androidx.work:work-testing", version.ref = "work" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,3 @@
 include ':app'
+
+enableFeaturePreview("VERSION_CATALOGS")


### PR DESCRIPTION
This PR introduced Dagger Hilt to the app, but also does a couple more things:
* Introduce the use of Gradle Library Catalogs, to maintain versions in a single place.
* Simplify `compileSdk`, `targetSdk`, and `minSdk`.