### PR TITLE
Increase compileSdk/targetSdk to 31 (fixes #24).

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,11 +6,11 @@ plugins {
 }
 
 android {
-    compileSdk = 30
+    compileSdk = 31
 
     defaultConfig {
         applicationId "dev.sjaramillo.pedometer"
-        targetSdk 30 // Check https://github.com/sjaramillo10/Pedometer/pull/14 before increasing version
+        targetSdk 31
         minSdk 21
         versionCode 1
         versionName "0.1.0"

--- a/app/src/main/kotlin/dev/sjaramillo/pedometer/worker/StepsCounterWorker.kt
+++ b/app/src/main/kotlin/dev/sjaramillo/pedometer/worker/StepsCounterWorker.kt
@@ -127,7 +127,7 @@ class StepsCounterWorker @AssistedInject constructor(
         fun enqueuePeriodicWork(context: Context) {
             val stepsCounterWorker =
                 PeriodicWorkRequestBuilder<StepsCounterWorker>(15, TimeUnit.MINUTES)
-                    //.setExpedited(OutOfQuotaPolicy.DROP_WORK_REQUEST)
+                    //.setExpedited(OutOfQuotaPolicy.DROP_WORK_REQUEST) Use this when expedited jobs can have a delay/be periodic
                     .addTag("stepsWork")
                     .build()
 

--- a/app/src/main/kotlin/dev/sjaramillo/pedometer/worker/StepsCounterWorker.kt
+++ b/app/src/main/kotlin/dev/sjaramillo/pedometer/worker/StepsCounterWorker.kt
@@ -85,10 +85,7 @@ class StepsCounterWorker @AssistedInject constructor(
         )
     }
 
-    /*
-     * Creates an instance of ForegroundInfo required to run this Worker as expedited.
-     */
-    private fun getForegroundInfo(): ForegroundInfo {
+    override suspend fun getForegroundInfo(): ForegroundInfo {
         val title = applicationContext.getString(R.string.notification_title)
         val content = applicationContext.getString(R.string.notification_content)
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,6 +50,11 @@
     <string name="activity_recognition_permission_required_message">Without the Activity Recognition permission, Pedometer is not able to count your steps.\n\nIf you want to use Pedometer, please grant the Activity Recognition permission in your device\'s settings.</string>
     <string name="activity_recognition_permission_required_positive_button">I understand</string>
 
+    <string name="ignore_battery_optimization_title">Ignore battery optimization</string>
+    <string name="ignore_battery_optimization_message">Pedometer tries to use the least amount of battery possible, but in order to work properly it needs the ability to run periodic jobs in the background.\n\nPlease allow Pedometer the ability to run such jobs in the background.</string>
+    <string name="ignore_battery_optimization_positive_button">Allow</string>
+    <string name="ignore_battery_optimization_negative_button">No Thanks</string>
+
     <string name="notification_channel_name">Info</string>
     <string name="notification_channel_description">Regular updates</string>
     <string name="notification_title">Pedometer</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ material = "1.4.0"
 navigation = "2.3.5"
 preference = "1.1.1"
 room = "2.3.0"
-work = "2.6.0" # Check https://github.com/sjaramillo10/Pedometer/pull/14 before increasing version
+work = "2.7.0"
 
 [libraries]
 activity = { module = "androidx.activity:activity-ktx", version.ref = "activity" }


### PR DESCRIPTION
Using compileSdk/targetSdk is a requirement in order to be able to use the latest versions of libraries such as AppCompat, ViewModel, WorkManager, Material Components, etc.

Another thing happening in this PR is bumping the WorkManager lib version to 2.7.0, plus some changes to work around the [Restrictions on foreground starts](https://developer.android.com/guide/components/foreground-services#background-start-restrictions). Check #14 for more information about such restrictions.